### PR TITLE
Change basic delimiter to regex delimiter

### DIFF
--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -1254,7 +1254,7 @@ inline static ncnn::Mat prompt_solve(std::unordered_map<std::string, int>& token
             for (std::string token : tokens)
             {
                 printf("Token: \"%s\"\n", token.c_str());
-                if (tokenizer_token2idx.find(token) != tokenizer_token2idx.end()) 
+                if (tokenizer_token2idx.find(token) != tokenizer_token2idx.end())
                     ids.push_back(tokenizer_token2idx[token]);
                 else
                     printf("Warning token: \"%s\" was ignored\n", token.c_str());


### PR DESCRIPTION
Small thing I noticed while debugging, we do some pretty basic delimiter splitting and so in some cases this can cause the wrong token to be used resulting in subpar images.

This PR is upgrading the basic delimiter splitting to use regex with a similar pattern to what CLIP uses, its not exactly the same due to Python regex supporting Unicode but it is probably good enough for our purposes.

https://github.com/huggingface/transformers/blob/main/src/transformers/models/clip/tokenization_clip.py#L318

|||
|-|-|
|![image](https://github.com/user-attachments/assets/52e36909-5d47-48e5-85d8-7404815a8098)|![image](https://github.com/user-attachments/assets/f3a2803b-f7e6-405c-ac94-3931b716718c)|
