### PR TITLE
sd.cpp: memory usage for Termux

### DIFF
--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -35,6 +35,10 @@
 #include <filesystem>
 #include <regex>
 
+#ifdef __ANDROID__
+#include <sys/resource.h>
+#endif
+
 #if USE_NCNN
 #include "benchmark.h"
 #include "net.h"
@@ -2250,6 +2254,15 @@ int main(int argc, char** argv)
     auto pwss = (size_t)info.PeakWorkingSetSize;
 
     printf("\npeak working set size: %f GB\n", static_cast<float>(pwss) / 1024.0f / 1024.0f / 1024.0f);
+
+#elif defined(__ANDROID__)
+
+    struct rusage ru;
+    if (!getrusage(RUSAGE_SELF, &ru)) {
+        auto mrss = ru.ru_maxrss;
+
+        printf("\nmaximum resident set size: %f GB\n", static_cast<float>(mrss) / 1024.0f / 1024.0f);
+    }
 
 #endif
 


### PR DESCRIPTION
I didn't test it with OpenCL, but in CPU-only mode it works.

And thank you for the program.