### PR TITLE
sd.cpp: turn off tiled decoding for small images

### DIFF
--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -1651,6 +1651,10 @@ void sdxl_decoder(ncnn::Mat& sample, const std::string& output_png_path, bool ti
             }
         };
 
+// Already checked in main()
+//        if (g_main_args.m_latw < 32 || g_main_args.m_lath < 32)
+//            throw std::invalid_argument("sdxl_decoder: resolution too small for the tiled decoder; use the --not-tiled option.");
+
         for (int y = 0; y < g_main_args.m_lath; y += 24)
         {
             if (y + 32 > g_main_args.m_lath)


### PR DESCRIPTION
1) For small images, OnnxStream uses almost same amount of memory with and without tiling, therefore it will not benefit from tiling much.
Turning tiling off automatically would avoid the need to do it manually for different sizes.

2) Move size check before processing, to not waist time for diffusion when image can not be decoded.

3) Images less than 40 pixels wide throw non-descriptive error:
<i>----------------[diffusion]---------------<br>step:0 === ERROR === AttentionFusedOps: m_attention_fused_ops_parts is not valid.</i><br>
Add check to avoid it.

And thank you for the program. 🙂