### PR TITLE
sd.cpp: add option to set number of threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ These are the command line options of the Stable Diffusion example:
 --curl-parallel     Sets the number of parallel downloads with CURL. Default is 16.
 --rpi               Configures the models to run on a Raspberry Pi.
 --rpi-lowmem        Configures the models to run on a Raspberry Pi Zero 2.
+--threads           Sets the number of threads, negative values use (cores - N) threads.
 ```
 
 Options you're probably interested in: `--xl`, `--turbo`, `--prompt`, `--steps`, `--rpi`.

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -689,7 +689,7 @@ inline static ncnn::Mat decoder_solver(ncnn::Mat& sample)
 #if USE_NCNN
     ncnn::Net net;
     {
-        net.opt.num_threads = n_threads;
+        if (n_threads) net.opt.num_threads = n_threads;
         net.opt.use_vulkan_compute = false;
         net.opt.use_winograd_convolution = false;
         net.opt.use_sgemm_convolution = false;
@@ -968,7 +968,7 @@ inline static ncnn::Mat diffusion_solver(int seed, int step, const ncnn::Mat& c,
     ncnn::Net net;
 #if USE_NCNN
     {
-        net.opt.num_threads = n_threads;
+        if (n_threads) net.opt.num_threads = n_threads;
         net.opt.use_vulkan_compute = false;
         net.opt.use_winograd_convolution = true; // false;
         net.opt.use_sgemm_convolution = true; // false;
@@ -1563,7 +1563,7 @@ inline static std::pair<ncnn::Mat, ncnn::Mat> prompt_solver(std::string const& p
     {
         // 加载CLIP模型
 #if USE_NCNN
-        net.opt.num_threads = n_threads;
+        if (n_threads) net.opt.num_threads = n_threads;
         net.opt.use_vulkan_compute = false;
         net.opt.use_winograd_convolution = false;
         net.opt.use_sgemm_convolution = false;

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -36,7 +36,6 @@
 #include <cstring>
 #include <filesystem>
 #include <regex>
-#include <thread>
 
 #ifdef __ANDROID__
 #include <sys/resource.h>

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -12,7 +12,7 @@
 #define NOMINMAX
 #include <windows.h>
 #include <psapi.h>
-#else
+#elif defined(__linux__)
 #include <unistd.h>   // for sysconf()
 #endif
 


### PR DESCRIPTION
It is already supported in OnnxStream, so simply activate it.

Logic:
- if N > 0, threads = N;
- if N <= 0, threads = _SC_NPROCESSORS_ONLN - N;
- if N is omitted, use default number.

And thank you for the program.