### PR TITLE
sd.cpp: handle sysconf() errors

### DIFF
--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -2114,7 +2114,7 @@ int main(int argc, char** argv)
             GetSystemInfo(&si);
             n_threads = static_cast<unsigned>(si.dwNumberOfProcessors);
 #elif defined(__linux__)
-            n_threads = static_cast<unsigned>(sysconf(_SC_NPROCESSORS_ONLN));
+            n_threads = static_cast<unsigned>(std::max(0L, sysconf(_SC_NPROCESSORS_ONLN)));
 #else
 #warning Number of threads can be default
 #endif


### PR DESCRIPTION
In case when _SC_NPROCESSORS_ONLN is not supported, sysconf() can return -1.
Then sd will not allow to set less than max(args.threads, 1 - (-1)) = 2 threads.

Treat sysconf() error result as "uncomputable" in std::thread::hardware_concurrency().

And thank you for the program