### PR TITLE
sd.cpp: display download error

### DIFF
--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -2287,8 +2287,14 @@ int main(int argc, char** argv)
                     command += " -o \"" + url.second + "\" \"" + url.first + "\" ";
                 command += " >" + null_device + " 2>&1";
 
-                if (system(command.c_str()))
-                    throw std::invalid_argument("Download error.");
+                if (system(command.c_str())) {
+                    command = "curl --location --fail --silent --show-error --parallel ";
+                    for (const auto& url : urls)
+                        command += " -o \"" + url.second + "\" \"" + url.first + "\" ";
+                    printf("Download error, retrying command:\n%s\n", command.c_str());
+                    if (system(command.c_str()))
+                        throw std::invalid_argument("Download failed.");
+                }
             };
 
             {


### PR DESCRIPTION
Currently, when `sd` can not download model files, it simply displays "Download error" and output of `curl` is hidden.
It could be useful to retry download with error printing.

For example, in my case there were only 16 kb left in Termux folder and it did install curl somehow, but failed to install libcurl.
So curl was showing linkage errors and could not start.

And thank you for the program.
