### PR TITLE
sd.cpp: Clang complains about -Wformat-security

### DIFF
--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -2053,7 +2053,7 @@ int main(int argc, char** argv)
         }
         else
         {
-            printf(("Invalid command line argument: \"" + arg + "\".\n\n").c_str());
+            printf("Invalid command line argument: \"%s\".\n\n", arg.c_str());
 
             printf("--xl                Runs Stable Diffusion XL 1.0 instead of Stable Diffusion 1.5.\n");
             printf("--turbo             Runs Stable Diffusion Turbo 1.0 instead of Stable Diffusion 1.5.\n");
@@ -2083,7 +2083,7 @@ int main(int argc, char** argv)
         {
             if (++i >= argc)
             {
-                printf(("Argument \"" + arg + "\" should be followed by a string.").c_str());
+                printf("Argument \"%s\" should be followed by a string.", arg.c_str());
                 return -1;
             }
 


### PR DESCRIPTION
Silences 2 warnings about "insecure" printf() template:
`warning: format string is not a string literal (potentially insecure) [-Wformat-security]`

And thank you for the program.