### PR TITLE
Add preview of diffuser steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,9 @@ These are the command line options of the Stable Diffusion example:
 --rpi               Configures the models to run on a Raspberry Pi.
 --rpi-lowmem        Configures the models to run on a Raspberry Pi Zero 2.
 --threads           Sets the number of threads, negative values use (cores - N) threads.
+--preview-steps     Save every diffusion step in low resolution.
+--preview-steps-x8  Magnify previews to full resolution.
+--decode-steps      Decode and save every diffusion step in full resolution.
 ```
 
 Options you're probably interested in: `--xl`, `--turbo`, `--prompt`, `--steps`, `--rpi`.

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -743,20 +743,31 @@ inline static void sd_preview(ncnn::Mat& sample, const std::string& filename, co
     float *rp = res.channel(0),
           *gp = res.channel(1),
           *bp = res.channel(2);
-    unsigned long cp = 0;
+    float *c0 = sample.channel(0),
+          *c1 = sample.channel(1),
+          *c2 = sample.channel(2),
+          *c3 = sample.channel(3);
     for (unsigned y = 0; y < height; y++) {
         for (unsigned x = 0; x < width; x++) {
-            float r = 0, g = 0, b = 0;
-            for (unsigned d = 0; d < 4; d++) {
-                float value = *(sample.channel(d) + cp);
-                r += value * sd_latent_rgb_proj[d][0];
-                g += value * sd_latent_rgb_proj[d][1];
-                b += value * sd_latent_rgb_proj[d][2];
-            }
-            *(rp++) = r;
-            *(gp++) = g;
-            *(bp++) = b;
-            cp++;
+            float value = *(c0++);
+            float r = value * sd_latent_rgb_proj[0][0];
+            float g = value * sd_latent_rgb_proj[0][1];
+            float b = value * sd_latent_rgb_proj[0][2];
+
+            value = *(c1++);
+            r += value * sd_latent_rgb_proj[1][0];
+            g += value * sd_latent_rgb_proj[1][1];
+            b += value * sd_latent_rgb_proj[1][2];
+
+            value = *(c2++);
+            r += value * sd_latent_rgb_proj[2][0];
+            g += value * sd_latent_rgb_proj[2][1];
+            b += value * sd_latent_rgb_proj[2][2];
+
+            value = *(c3++);
+            *(rp++) = r + value * sd_latent_rgb_proj[3][0];
+            *(gp++) = g + value * sd_latent_rgb_proj[3][1];
+            *(bp++) = b + value * sd_latent_rgb_proj[3][2];
         }
     }
 
@@ -793,20 +804,31 @@ inline static void sdxl_preview(ncnn::Mat& sample, const std::string& filename, 
     float *rp = res.channel(0),
           *gp = res.channel(1),
           *bp = res.channel(2);
-    unsigned long cp = 0;
+    float *c0 = sample.channel(0),
+          *c1 = sample.channel(1),
+          *c2 = sample.channel(2),
+          *c3 = sample.channel(3);
     for (unsigned y = 0; y < height; y++) {
         for (unsigned x = 0; x < width; x++) {
-            float r = 0, g = 0, b = 0;
-            for (unsigned d = 0; d < 4; d++) {
-                float value = *(sample.channel(d) + cp);
-                r += value * sdxl_latent_rgb_proj[d][0];
-                g += value * sdxl_latent_rgb_proj[d][1];
-                b += value * sdxl_latent_rgb_proj[d][2];
-            }
-            *(rp++) = r;
-            *(gp++) = g;
-            *(bp++) = b;
-            cp++;
+            float value = *(c0++);
+            float r = value * sdxl_latent_rgb_proj[0][0];
+            float g = value * sdxl_latent_rgb_proj[0][1];
+            float b = value * sdxl_latent_rgb_proj[0][2];
+
+            value = *(c1++);
+            r += value * sdxl_latent_rgb_proj[1][0];
+            g += value * sdxl_latent_rgb_proj[1][1];
+            b += value * sdxl_latent_rgb_proj[1][2];
+
+            value = *(c2++);
+            r += value * sdxl_latent_rgb_proj[2][0];
+            g += value * sdxl_latent_rgb_proj[2][1];
+            b += value * sdxl_latent_rgb_proj[2][2];
+
+            value = *(c3++);
+            *(rp++) = r + value * sdxl_latent_rgb_proj[3][0];
+            *(gp++) = g + value * sdxl_latent_rgb_proj[3][1];
+            *(bp++) = b + value * sdxl_latent_rgb_proj[3][2];
         }
     }
 

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -743,11 +743,12 @@ inline static void sd_preview(ncnn::Mat& sample, const std::string& filename, co
     float *rp = res.channel(0),
           *gp = res.channel(1),
           *bp = res.channel(2);
+    unsigned long cp = 0;
     for (unsigned y = 0; y < height; y++) {
         for (unsigned x = 0; x < width; x++) {
             float r = 0, g = 0, b = 0;
             for (unsigned d = 0; d < 4; d++) {
-                float value = *(sample.channel(d) + y * width + x);
+                float value = *(sample.channel(d) + cp);
                 r += value * sd_latent_rgb_proj[d][0];
                 g += value * sd_latent_rgb_proj[d][1];
                 b += value * sd_latent_rgb_proj[d][2];
@@ -755,6 +756,7 @@ inline static void sd_preview(ncnn::Mat& sample, const std::string& filename, co
             *(rp++) = r;
             *(gp++) = g;
             *(bp++) = b;
+            cp++;
         }
     }
 
@@ -791,11 +793,12 @@ inline static void sdxl_preview(ncnn::Mat& sample, const std::string& filename, 
     float *rp = res.channel(0),
           *gp = res.channel(1),
           *bp = res.channel(2);
+    unsigned long cp = 0;
     for (unsigned y = 0; y < height; y++) {
         for (unsigned x = 0; x < width; x++) {
             float r = 0, g = 0, b = 0;
             for (unsigned d = 0; d < 4; d++) {
-                float value = *(sample.channel(d) + y * width + x);
+                float value = *(sample.channel(d) + cp);
                 r += value * sdxl_latent_rgb_proj[d][0];
                 g += value * sdxl_latent_rgb_proj[d][1];
                 b += value * sdxl_latent_rgb_proj[d][2];
@@ -803,6 +806,7 @@ inline static void sdxl_preview(ncnn::Mat& sample, const std::string& filename, 
             *(rp++) = r;
             *(gp++) = g;
             *(bp++) = b;
+            cp++;
         }
     }
 

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -55,6 +55,8 @@
 #include "net.h"
 #endif
 
+#define SHOW_LONG_TIME_MS(a) std::cout << static_cast<long>(a) << "ms" << std::endl;
+
 #if USE_ONNXSTREAM
 #include "onnxstream.h"
 using namespace onnxstream;
@@ -1240,7 +1242,7 @@ inline static ncnn::Mat diffusion_solver(int seed, int step, const ncnn::Mat& c,
             double t1 = ncnn::get_current_time();
             ncnn::Mat denoised = CFGDenoiser_CompVisDenoiser(net, log_sigmas, x_mat, sigma[i], c, uc, sdxl_params, model);
             double t2 = ncnn::get_current_time();
-            std::cout << t2 - t1 << "ms" << std::endl;
+            SHOW_LONG_TIME_MS( t2 - t1 )
             float sigma_up = std::min(sigma[i + 1], std::sqrt(sigma[i + 1] * sigma[i + 1] * (sigma[i] * sigma[i] - sigma[i + 1] * sigma[i + 1]) / (sigma[i] * sigma[i])));
             float sigma_down = std::sqrt(sigma[i + 1] * sigma[i + 1] - sigma_up * sigma_up);
             std::srand(seed++);
@@ -1271,7 +1273,7 @@ inline static ncnn::Mat diffusion_solver(int seed, int step, const ncnn::Mat& c,
                     sdxl_preview(x_mat, output_path, im_appendix);
                 }
                 double t2 = ncnn::get_current_time();
-                std::cout << t2 - t1 << "ms" << std::endl;
+                SHOW_LONG_TIME_MS( t2 - t1 )
             }
             if(g_main_args.m_decode_im                            // pass through decoder
                && i < static_cast<int>(sigma.size()) - 2) {       // if step is not last
@@ -1291,7 +1293,7 @@ inline static ncnn::Mat diffusion_solver(int seed, int step, const ncnn::Mat& c,
                     sdxl_decoder(sample, output_path, /* tiled */ g_main_args.m_tiled, im_appendix);
                 }
                 double t2 = ncnn::get_current_time();
-                std::cout << t2 - t1 << "ms" << std::endl;
+                SHOW_LONG_TIME_MS( t2 - t1 )
             }
         }
     }

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -739,8 +739,10 @@ inline static void sd_preview(ncnn::Mat& sample, const std::string& filename, co
         {-0.2120f, -0.2616f, -0.7177f}};
 
     unsigned width = sample.w, height = sample.h;
-    unsigned long pixel = 0;
     ncnn::Mat res = ncnn::Mat(width, height, 3);
+    float *rp = res.channel(0),
+          *gp = res.channel(1),
+          *bp = res.channel(2);
     for (unsigned y = 0; y < height; y++) {
         for (unsigned x = 0; x < width; x++) {
             float r = 0, g = 0, b = 0;
@@ -750,10 +752,9 @@ inline static void sd_preview(ncnn::Mat& sample, const std::string& filename, co
                 g += value * sd_latent_rgb_proj[d][1];
                 b += value * sd_latent_rgb_proj[d][2];
             }
-            *(res.channel(0) + pixel) = r;
-            *(res.channel(1) + pixel) = g;
-            *(res.channel(2) + pixel) = b;
-            pixel++;
+            *(rp++) = r;
+            *(gp++) = g;
+            *(bp++) = b;
         }
     }
 
@@ -786,8 +787,10 @@ inline static void sdxl_preview(ncnn::Mat& sample, const std::string& filename, 
         {-0.3165f, -0.2492f, -0.2188f}};
 
     unsigned width = sample.w, height = sample.h;
-    unsigned long pixel = 0;
     ncnn::Mat res = ncnn::Mat(width, height, 3);
+    float *rp = res.channel(0),
+          *gp = res.channel(1),
+          *bp = res.channel(2);
     for (unsigned y = 0; y < height; y++) {
         for (unsigned x = 0; x < width; x++) {
             float r = 0, g = 0, b = 0;
@@ -797,10 +800,9 @@ inline static void sdxl_preview(ncnn::Mat& sample, const std::string& filename, 
                 g += value * sdxl_latent_rgb_proj[d][1];
                 b += value * sdxl_latent_rgb_proj[d][2];
             }
-            *(res.channel(0) + pixel) = r;
-            *(res.channel(1) + pixel) = g;
-            *(res.channel(2) + pixel) = b;
-            pixel++;
+            *(rp++) = r;
+            *(gp++) = g;
+            *(bp++) = b;
         }
     }
 

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -1262,17 +1262,21 @@ inline static ncnn::Mat diffusion_solver(int seed, int step, const ncnn::Mat& c,
             }
 
             if(g_main_args.m_preview_im) {       // directly decode latent in low resolution
-                std::cout << "---> [preview]" << std::endl;
+                std::cout << "---> preview:\t\t";
+                double t1 = ncnn::get_current_time();
                 const std::string im_appendix = "_preview_" + std::to_string(i);
                 if(!sdxl_params) {
                     sd_preview(x_mat, output_path, im_appendix);
                 } else {
                     sdxl_preview(x_mat, output_path, im_appendix);
                 }
+                double t2 = ncnn::get_current_time();
+                std::cout << t2 - t1 << "ms" << std::endl;
             }
             if(g_main_args.m_decode_im                            // pass through decoder
                && i < static_cast<int>(sigma.size()) - 2) {       // if step is not last
-                std::cout << "---> [decode]" << std::endl;
+                std::cout << "---> decode:\t\t";
+                double t1 = ncnn::get_current_time();
                 ncnn::Mat sample = ncnn::Mat(x_mat.w, x_mat.h, x_mat.c, x_mat.v.data());
                 const std::string im_appendix = "_" + std::to_string(i);
                 if(!sdxl_params) {
@@ -1286,6 +1290,8 @@ inline static ncnn::Mat diffusion_solver(int seed, int step, const ncnn::Mat& c,
                 } else {
                     sdxl_decoder(sample, output_path, /* tiled */ g_main_args.m_tiled, im_appendix);
                 }
+                double t2 = ncnn::get_current_time();
+                std::cout << t2 - t1 << "ms" << std::endl;
             }
         }
     }


### PR DESCRIPTION
As was suggested here: https://github.com/vitoplantamura/OnnxStream/issues/38.

- **--preview-steps** saves "**image.jpg_preview_[step number].jpg**" in resolution 64x64 (128x128 for sdxl) with fast direct latents decoding;
- **--preview-steps-x8** saves same directly decoded image with 8x "nearest neighbour" upscaling, with 512x512 / 1024x1024 size;
- **--decode-steps** fully decodes images after every step.

Direct latents decoding by @stduhpf is taken from https://github.com/leejet/stable-diffusion.cpp/pull/454, I hope he won't mind.

Example (fast/full decoding):
![onnxstream png_2025-03-23T13-47-16 png jpg_preview_9](https://github.com/user-attachments/assets/0caf12f3-a3f9-4b64-92b9-6f8004fa1bad) ![onnxstream png_2025-03-23T13-47-16 png](https://github.com/user-attachments/assets/0422a31d-f114-4985-8a07-de6b996d45fe)

Latents (model SDXL Turbo, prompt "cute kitten, green apple and red cup on blue table, sunny morning", seed 709632, 10 steps): 
[latent.zip](https://github.com/user-attachments/files/19409438/latent.zip).

And thank you for the program.