### PR TITLE
sd.cpp: embed generation parameters into images

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ These are the command line options of the Stable Diffusion example:
 --preview-steps     Save every diffusion step in low resolution.
 --preview-steps-x8  Magnify previews to full resolution.
 --decode-steps      Decode and save every diffusion step in full resolution.
+--embed-parameters  Store parameters of generation (e. g. model path) in image comments.
 ```
 
 Options you're probably interested in: `--xl`, `--turbo`, `--prompt`, `--steps`, `--rpi`.

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -445,6 +445,7 @@ inline static void save_image(std::uint8_t* img, unsigned w, unsigned h, int alp
             png_write_row(png_ptr, (png_const_bytep)(img + y * w));
         }
     }
+    png_write_end(png_ptr, info_ptr);
     png_destroy_write_struct(&png_ptr, &info_ptr);
     }
     fclose(fp);
@@ -565,7 +566,7 @@ inline static void save_image(std::uint8_t* img, unsigned w, unsigned h, int alp
     if (options.length()) { // skip empty comment insertion
         // making a pair { key, value }, same as in png_set_text()
         const std::string comment = std::string("parameters\0", strlen("parameters") + 1) \
-                                  + options + std::string("\0", 1);
+                                  + options;
 
         // writing comment chunk: length + "tEXt" + comment + checksum
         {


### PR DESCRIPTION
The parameters are stored as a pair of null-separated strings { "parameters", "..." } in format, compatible with [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp/blob/81556f3136d7881ef3b34ec2aa650cf760d52601/examples/cli/main.cpp#L715) and maybe [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/d57ff884edd5fe3e813dbb65adb45a8966dd15b2/modules/infotext_utils.py#L237) (prompt`\n`Negative prompt: neg-prompt`\n`Steps: 5, ...).

- libpng creates the pair { key, value } with png_set_text() automatically;
- for uncompressed PNGs, the pair is merged manually and then the comment chunk is written similarly to IHDR chunk (length + tEXt + string + checksum);
- for libjpeg-turbo, the comment length is limited to 65535 bytes (https://www.w3.org/Graphics/JPEG/itu-t81.pdf, p. 44, table B.8), therefore the text is truncated to fit.

And thank you for the program!