### PR TITLE
sd.cpp: add option to disable auto-downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ These are the command line options of the Stable Diffusion example:
 --preview-steps     Save every diffusion step in low resolution.
 --preview-steps-x8  Magnify previews to full resolution.
 --decode-steps      Decode and save every diffusion step in full resolution.
+--not-autodownload  Do not download models automatically.
 ```
 
 Options you're probably interested in: `--xl`, `--turbo`, `--prompt`, `--steps`, `--rpi`.

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ These are the command line options of the Stable Diffusion example:
 --not-tiled         (ONLY SDXL 1.0 and TURBO) Don't use the tiled VAE decoder.
 --res               (ONLY TURBO) Sets the output PNG file resolution. Default is "512x512".
 --ram               Uses the RAM WeightsProvider (Experimental).
---download          Forces the (re)download of the current model.
+--download          A[uto] / F[orce] / N[ever] (re)download current model.
 --curl-parallel     Sets the number of parallel downloads with CURL. Default is 16.
 --rpi               Configures the models to run on a Raspberry Pi.
 --rpi-lowmem        Configures the models to run on a Raspberry Pi Zero 2.
@@ -362,7 +362,6 @@ These are the command line options of the Stable Diffusion example:
 --preview-steps     Save every diffusion step in low resolution.
 --preview-steps-x8  Magnify previews to full resolution.
 --decode-steps      Decode and save every diffusion step in full resolution.
---not-autodownload  Do not download models automatically.
 ```
 
 Options you're probably interested in: `--xl`, `--turbo`, `--prompt`, `--steps`, `--rpi`.

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -2648,7 +2648,7 @@ int main(int argc, char** argv)
     }
 
     if (!g_main_args.m_download) {
-        printf("The model \"%s\" is not found and needs to be downloaded, "
+        printf("The model \"%s\" needs to be downloaded, "
                "but auto-downloading is disabled from command line.\n"
                "Exiting.\n",
                g_main_args.m_path_with_slash.c_str());

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -2245,7 +2245,7 @@ int main(int argc, char** argv)
         else if (arg == "--download")
         {
             if (i + 1 >= argc || !strncmp(argv[i + 1], "--", 2)) { // not moving argv[] index yet
-                g_main_args.m_download = 'f';                      // no value == force
+                g_main_args.m_download = 'f'; // no value == force
                 continue;
             }
             char d = tolower(argv[++i][0]); // char or 0

--- a/src/sd.cpp
+++ b/src/sd.cpp
@@ -84,6 +84,7 @@ struct MainArgs
     bool m_decode_im = false;
     bool m_preview_im = false;
     bool m_preview_8x = false;
+    bool m_not_autodownload = false;
     std::string m_curl_parallel = "16";
     std::string m_res = "";
     std::string m_threads = "";
@@ -2229,6 +2230,10 @@ int main(int argc, char** argv)
         {
             g_main_args.m_tiled = false;
         }
+        else if (arg == "--not-autodownload")
+        {
+            g_main_args.m_not_autodownload = true;
+        }
         else if (arg == "--rpi-lowmem")
         {
             g_main_args.m_rpi = true;
@@ -2294,6 +2299,7 @@ int main(int argc, char** argv)
             printf("--rpi               Configures the models to run on a Raspberry Pi.\n");
             printf("--rpi-lowmem        Configures the models to run on a Raspberry Pi Zero 2.\n");
             printf("--threads           Sets the number of threads, values =< 0 mean max-N.\n");
+            printf("--not-autodownload  Do not download models automatically.\n");
 
             return -1;
         }
@@ -2495,7 +2501,7 @@ int main(int argc, char** argv)
             }
         }
 
-        if (g_main_args.m_download)
+        if (!g_main_args.m_not_autodownload && g_main_args.m_download)
         {
             std::string url_with_slash = "https://huggingface.co/" + full_repo_name + "/resolve/main/";
 
@@ -2626,6 +2632,14 @@ int main(int argc, char** argv)
         }
 
         return 0;
+    }
+
+    if (g_main_args.m_not_autodownload && g_main_args.m_download) {
+        printf("The nodel \"%s\" is not found and needs to be downloaded, "
+               "but auto-downloading is disabled from command line.\n"
+               "Exiting.\n",
+               g_main_args.m_path_with_slash.c_str());
+        return -1;
     }
 
     try


### PR DESCRIPTION
It is useful when forgot to add or mistyped `--models-path`.

And thank you for the program.